### PR TITLE
fix: Dynamic cache path instead of hardcoded

### DIFF
--- a/appdaemon/apps/climatiq.yaml
+++ b/appdaemon/apps/climatiq.yaml
@@ -15,6 +15,10 @@ climatiq_controller:
   # Log file für RL Training
   log_file: /config/appdaemon/logs/climatiq_rl.jsonl
   
+  # Cache-Pfad für erkannte Zonen (optional)
+  # Falls nicht gesetzt: wird automatisch neben der App gespeichert
+  # cache_path: /config/appdaemon/apps/climatiq_zones_cache.json
+  
   # InfluxDB für historische Daten (Zonen-Erkennung)
   # Falls nicht konfiguriert: nutzt HA History (nur 7 Tage)
   influxdb:

--- a/appdaemon/apps/climatiq_controller.py
+++ b/appdaemon/apps/climatiq_controller.py
@@ -31,6 +31,13 @@ class ClimatIQController(hass.Hass):
         self.unstable_zones = []
         self.stable_zones = []
 
+        # Cache-Pfad: entweder aus Config oder relativ zum Script-Verzeichnis
+        if "cache_path" in self.args:
+            self.cache_path = self.args["cache_path"]
+        else:
+            script_dir = os.path.dirname(os.path.abspath(__file__))
+            self.cache_path = os.path.join(script_dir, "climatiq_zones_cache.json")
+
         # 1. Automatische Zonen-Erkennung beim Start
         self.log("=== ClimatIQ Controller V2 ===")
         self.log("Starte automatische Zonen-Erkennung...")
@@ -250,16 +257,15 @@ class ClimatIQController(hass.Hass):
 
     def _save_zones_cache(self):
         """Speichert erkannte Zonen in Cache-Datei"""
-        cache_path = "/config/appdaemon/apps/climatiq_zones_cache.json"
         cache = {
             "timestamp": datetime.now().isoformat(),
             "stable_zones": self.stable_zones,
             "unstable_zones": self.unstable_zones,
         }
         try:
-            with open(cache_path, "w") as f:
+            with open(self.cache_path, "w") as f:
                 json.dump(cache, f, indent=2)
-            self.log(f"Zonen-Cache gespeichert: {cache_path}")
+            self.log(f"Zonen-Cache gespeichert: {self.cache_path}")
         except Exception as e:
             self.log(f"Fehler beim Speichern des Cache: {e}", level="WARNING")
 


### PR DESCRIPTION
## Problem
The cache path was hardcoded as `/config/appdaemon/apps/climatiq_zones_cache.json`, causing errors on systems where AppDaemon uses different directory structures.

## Solution
- Cache path now automatically uses the directory where the script is located
- Added optional `cache_path` parameter in config for manual override
- Prevents "No such file or directory" errors across different AppDaemon installations (Docker, Core, Add-on)

## Changes
- `initialize()`: Dynamically sets `self.cache_path` based on `__file__` location or config
- `_save_zones_cache()`: Uses `self.cache_path` instead of hardcoded string
- `climatiq.yaml`: Added commented example for optional `cache_path` parameter