### PR TITLE
feat: Make RL log path optional with dynamic default

### DIFF
--- a/appdaemon/apps/climatiq.yaml
+++ b/appdaemon/apps/climatiq.yaml
@@ -12,8 +12,9 @@ climatiq_controller:
   # Interval (Minuten)
   interval_minutes: 5
   
-  # Log file für RL Training
-  log_file: /config/appdaemon/logs/climatiq_rl.jsonl
+  # Log file für RL Training (optional)
+  # Falls nicht gesetzt: climatiq_rl.jsonl im Script-Verzeichnis
+  # log_file: /config/appdaemon/logs/climatiq_rl.jsonl
   
   # Cache-Pfad für erkannte Zonen (optional)
   # Falls nicht gesetzt: wird automatisch neben der App gespeichert

--- a/appdaemon/apps/climatiq_controller.py
+++ b/appdaemon/apps/climatiq_controller.py
@@ -38,6 +38,13 @@ class ClimatIQController(hass.Hass):
             script_dir = os.path.dirname(os.path.abspath(__file__))
             self.cache_path = os.path.join(script_dir, "climatiq_zones_cache.json")
 
+        # RL Log-Pfad: optional, Default relativ zum Script
+        if "log_file" in self.args:
+            self.log_file = self.args["log_file"]
+        else:
+            script_dir = os.path.dirname(os.path.abspath(__file__))
+            self.log_file = os.path.join(script_dir, "climatiq_rl.jsonl")
+
         # 1. Automatische Zonen-Erkennung beim Start
         self.log("=== ClimatIQ Controller V2 ===")
         self.log("Starte automatische Zonen-Erkennung...")
@@ -454,7 +461,7 @@ class ClimatIQController(hass.Hass):
     def log_episode(self, state: Dict, actions: List[Dict], reward: Dict):
         """Loggt Episode für RL Training (JSONL)"""
 
-        log_file = self.args.get("log_file", "/config/appdaemon/logs/climatiq_rl.jsonl")
+        log_file = self.log_file
 
         episode = {
             "timestamp": state["timestamp"],


### PR DESCRIPTION
## Problem
The RL log file path was hardcoded in `log_episode()`, requiring manual configuration.

## Solution
Make the log path optional with automatic fallback to script directory - consistent with the cache path behavior from PR #3.

## Changes
- `initialize()`: Set `self.log_file` from config or default to `<script_dir>/climatiq_rl.jsonl`
- `log_episode()`: Use `self.log_file` instead of `args.get()` with hardcoded default
- `climatiq.yaml`: Document that `log_file` is now optional

## Fixes
Fixes #4